### PR TITLE
Change the bots response time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/" # Find the manifests
     schedule:
       interval: "daily"
-      time: "09:30" # update at 9:30 AM 
+      time: "09:00" # update at 9:00 AM 
       timezone: "America/Mexico_City" # use my current timezone
   # Now look for the pip dependencies
   # (example: setup.py files)
@@ -18,5 +18,5 @@ updates:
     directory: "/" # Find the manifests
     schedule:
       interval: "daily"
-      time: "09:30" # update at 9:30 AM 
+      time: "09:00" # update at 9:00 AM 
       timezone: "America/Mexico_City" # use my current timezone

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for Lock Threads - https://github.com/dessant/lock-threads-app
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 15
+daysUntilLock: 30
 
 # Skip issues and pull requests created before a given timestamp.
 skipCreatedBefore: false

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an Issue is closed for lack of response
-daysUntilClose: 10
+daysUntilClose: 15
 # Label requiring a response
 responseRequiredLabel: "Awaiting response"
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable


### PR DESCRIPTION
I consider that we must wait a little bit more before closing and locking something. I would like to do something like this:

- If no one gives a requested answer, `no-response` will close after 15 days.
- `lock` will lock the conversation after 30 days of inactivity.