### PR TITLE
Unify `nox` and `tox` ignores (on `.gitignore`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
-.tox/
-.nox/
+.[nt]ox/
 .coverage
 .coverage.*
 .cache


### PR DESCRIPTION
Unify these lines:

```gitignore
.tox/
.nox/
```

Using this one:

```gitignore
.[nt]ox/
```