### PR TITLE
Remove the `triage-new-issues` bot and replace it with issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-issue.md
+++ b/.github/ISSUE_TEMPLATE/security-issue.md
@@ -2,7 +2,7 @@
 name: Security vulnerability issue
 about: An issue about a security vulnerability
 title: ''
-labels: Security Issue
+labels: Security Issue, Please triage this
 asignees: DiddiLeija
 
 ---

--- a/.github/triage-new-issues.yml
+++ b/.github/triage-new-issues.yml
@@ -1,7 +1,0 @@
-# This is based off of reading the actual source code of the bot. :/
-# https://github.com/tunnckoCore/triage-new-issues/blob/master/src/index.js#L7
-#
-# While this file is currently a no-op, it serves the purpose of
-# documenting that this bot is indeed being used, since this is a
-# non-standard probot bot.
-label: "Please triage this"


### PR DESCRIPTION
This pull request will revert the changes made on #15 according to a commentary from #16:

> I don't know if we really need a `triage-new-issues` bot, as we can add the `Please triage this` label with issue templates.

So, we are going to:

- [x] Delete `triage-new-issues.yml`
- [x] Replace the bot functions using the issue templates (on the `label` argument)