### PR TITLE
Implement `black` in our tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # text_formatter
 
 [![Documentation Status](https://readthedocs.org/projects/text-formatter/badge/?version=latest)](https://text-formatter.readthedocs.io/en/latest/?badge=latest)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 Pretty formatter for Python strings.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ import nox
 @nox.session()
 def test(session):
     # install flake8 and isort
-    session.install("flake8", "isort")
+    session.install("flake8", "isort", "black")
     # stop the build if there are Python syntax errors
     # or undefined names. Consider that the GitHub editor
     # is 127-characters wide.
@@ -22,3 +22,4 @@ def test(session):
       "--statistic"
     )
     session.run("isort", ".", "--check-only", "-v")
+    session.run("black", "--check", ".")


### PR DESCRIPTION
Adopt black in our codebase.


<!--
Thanks for your contribution! Before going ahead, get sure
to read CONTRIBUTING.md or the contribution document
at our docs (https://text-formatter.readthedocs.io/en/latest/dev/contrib.html).
-->
