### PR TITLE
Remove `myst_parser`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,4 @@
 
 sphinx==5.2.2
 sphinx_copybutton==0.5.0
-myst_parser==0.18.1
 furo==2022.9.15


### PR DESCRIPTION
Seems like it's no longer needed.

Closes #110

<!--
Thanks for your contribution! Before going ahead, get sure
to read CONTRIBUTING.md or the contribution document
at our docs (https://text-formatter.readthedocs.io/en/latest/dev/contrib.html).
-->